### PR TITLE
Change dependencies to ensure correct order

### DIFF
--- a/deployment/bicep/main.bicep
+++ b/deployment/bicep/main.bicep
@@ -32,7 +32,7 @@ resource aseResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 
 module shared 'shared.bicep' = {
   name: 'sharedresources'
-  scope: resourceGroup(sharedResourceGroupName)
+  scope: resourceGroup(sharedRG.name)
   params: {
     location: location
     sharedResourceGroupResources : sharedResourceGroupResources
@@ -43,7 +43,7 @@ module ase 'ase.bicep' = {
   dependsOn: [
     shared
   ]
-  scope: resourceGroup(aseResourceGroupName)
+  scope: resourceGroup(aseResourceGroup.name)
   name: 'aseresources'
   params: {
     location: location


### PR DESCRIPTION
Changed references between modules and resource groups to ensure correct order of execution.

Tested with: az deployment sub create --location southcentralus --name bicepdemo5 --template-file .\deployment\bicep\main.bicep --parameters workloadName=nptest5 environment=dev

Still creating the ASE ... warning: this can take a number of hours