### PR TITLE
ensure kv name doesn't end with dash

### DIFF
--- a/deployment/bicep/ase.bicep
+++ b/deployment/bicep/ase.bicep
@@ -72,6 +72,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2021-01-15' = {
 
 resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   name: privateDnsZoneName
+  location: location
   properties: {}
   dependsOn: [
     ase

--- a/deployment/bicep/shared/shared.bicep
+++ b/deployment/bicep/shared/shared.bicep
@@ -45,8 +45,9 @@ param resourceSuffix string
 ])
 param environment string
 
-// Variables
-var keyVaultName = take('kv-${resourceSuffix}', 24) // Must be between 3-24 alphanumeric characters 
+// Variables - ensure key vault name does not end with '-'
+var tempKeyVaultName = take('kv-${resourceSuffix}', 24) // Must be between 3-24 alphanumeric characters 
+var keyVaultName = (lastIndexOf(tempKeyVaultName, '-') + 1 == length(tempKeyVaultName)) ? substring(tempKeyVaultName, 0, length(tempKeyVaultName) - 1) : tempKeyVaultName
 
 // Resources
 module appInsights './azmon.bicep' = {


### PR DESCRIPTION
Fixes #48 ... check for a dash at the end of the shortened key vault name, and then trim to remove that dash