### PR TITLE
updating readme to callout pricing model and zone redundant default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Deployed Resources:
 
 ![image](https://user-images.githubusercontent.com/37597107/133897451-9a6d0a07-873c-4f87-81de-29b15d576e4b.png)
 
+Important Points:
+
+1. Here are the [pricing models for ASE V3](https://docs.microsoft.com/en-us/azure/app-service/environment/overview#pricing). The current default is to deploy an ASE V3 that is zone-redundant and one Isolated V2 SKU Windows App Service Plan scaled to 3 instances (default with zone redundancy)
+


### PR DESCRIPTION
Wanted to add an 'important points' section so that teams can be made aware of considerations should they deploy the default setup. One of those is the pricing model, since currently this deployment will enable zone-redundancy on the ASE V3 and therefore should take note of the following: https://docs.microsoft.com/en-us/azure/app-service/environment/overview#pricing